### PR TITLE
Use websocket-client for template-rendering

### DIFF
--- a/dist/html-template-card.js
+++ b/dist/html-template-card.js
@@ -1,83 +1,94 @@
-class HtmlTemplateCard extends HTMLElement {
-    static get properties() {
-        return {
-            _config: {},
-            _hass: {},
-        };
-    }
+customElements.whenDefined('card-tools').then(() => {
+    var cardTools = customElements.get('card-tools');
 
-    set hass(hass) {
-        const oldHass = this._hass;
-        this._hass = hass;
-        if (this._config && this._hass && !this._entities) {
-            this.calculateEntites();
+    class HtmlTemplateCard extends HTMLElement {
+        static get properties() {
+            return {
+                _config: {},
+                _hass: {},
+            };
         }
-        if (this.shouldUpdate(oldHass)) {
-            this.processAndRender();
-        }
-    }
 
-    shouldUpdate(oldHass) {
-        if (oldHass && this._entities && !this._config.always_update) {
-            let should = false;
-            this._entities.forEach(entity => {
-                should = should || oldHass.states[entity] !== this._hass.states[entity]
-                    || oldHass.states[entity].attributes !== this._hass.states[entity].attributes
-            });
-            return should;
-        }
-        return true;
-    }
-
-    setConfig(config) {
-        if (!config.content) {
-            throw new Error("You need to define 'content' in your configuration.")
-        }
-        this._config = config;
-        if (this._config && this._hass && !this._entities) {
-            this.calculateEntites();
-        }
-    }
-
-    calculateEntites() {
-        this._entities = [];
-        if (this._config.entities && Array.isArray(this._config.entities)) {
-            for (const entity in this._config.entities) {
-                this._entities.push(this._config.entities[entity]);
+        set hass(hass) {
+            const oldHass = this._hass;
+            this._hass = hass;
+            if (this._config && this._hass && !this._entities) {
+                this.calculateEntites();
+            }
+            if (this.shouldUpdate(oldHass)) {
+                this.processAndRender();
             }
         }
-        for (const entity in this._hass.states) {
-            if (this._config.content.includes(entity)) {
-                this._entities.push(this._hass.states[entity].entity_id);
+
+        shouldUpdate(oldHass) {
+            if (oldHass && this._entities && !this._config.always_update) {
+                let should = false;
+                this._entities.forEach(entity => {
+                    should = should || oldHass.states[entity] !== this._hass.states[entity]
+                        || oldHass.states[entity].attributes !== this._hass.states[entity].attributes
+                });
+                return should;
+            }
+            return true;
+        }
+
+        setConfig(config) {
+            if (!config.content) {
+                throw new Error("You need to define 'content' in your configuration.")
+            }
+            this._config = config;
+            if (this._config && this._hass && !this._entities) {
+                this.calculateEntites();
             }
         }
-    }
 
-    processAndRender() {
-        let content = this._config.content;
-        if (!this._config.ignore_line_breaks) {
-            content = content.replace(/\r?\n|\r/g, "</br>");
+        calculateEntites() {
+            this._entities = [];
+            if (this._config.entities && Array.isArray(this._config.entities)) {
+                for (const entity in this._config.entities) {
+                    this._entities.push(this._config.entities[entity]);
+                }
+            }
+            for (const entity in this._hass.states) {
+                if (this._config.content.includes(entity)) {
+                    this._entities.push(this._hass.states[entity].entity_id);
+                }
+            }
         }
-        if (!this._config.do_not_parse) {
-            this._hass.callApi("post", "template", {"template": content}).then(t => this.render(t));
-        } else {
-            this.render(content);
+
+        processAndRender() {
+            let content = this._config.content;
+            if (!this._config.ignore_line_breaks) {
+                content = content.replace(/\r?\n|\r/g, "</br>");
+            }
+            if (!this._config.do_not_parse) {
+                cardTools.subscribeRenderTemplate(this._hass.connection, (t) => { this.render(t); }, {"template": content})
+            } else {
+                this.render(content);
+            }
+        }
+
+        render(content) {
+            let header = ``;
+            if (this._config.title) {
+                header = `<div class="card-header" style="padding: 8px 0 16px 0;"><div class="name">${this._config.title}</div></div>`;
+            }
+            this.innerHTML = this._config.picture_elements_mode
+                ? content
+                : `<ha-card id="htmlCard" style="padding: 16px">${header}<div>${content}</div></ha-card>`;
+        }
+
+        getCardSize() {
+            return 1;
         }
     }
 
-    render(content) {
-        let header = ``;
-        if (this._config.title) {
-            header = `<div class="card-header" style="padding: 8px 0 16px 0;"><div class="name">${this._config.title}</div></div>`;
-        }
-        this.innerHTML = this._config.picture_elements_mode
-            ? content
-            : `<ha-card id="htmlCard" style="padding: 16px">${header}<div>${content}</div></ha-card>`;
-    }
+    customElements.define('html-template-card', HtmlTemplateCard);
+});
 
-    getCardSize() {
-        return 1;
-    }
-}
-
-customElements.define('html-template-card', HtmlTemplateCard);
+setTimeout(() => {
+  if(customElements.get('card-tools')) return;
+  customElements.define('html-template-card', class extends HTMLElement{
+      setConfig() { throw new Error("Can't find card-tools. See https://github.com/thomasloven/lovelace-card-tools");}
+  });
+}, 2000);


### PR DESCRIPTION
Motivation for this change:
- I wanted to use this with non-admin users.
- As the api-endpoint used for template-rendering is only available for admin-users this didn't work.
- After talking to people on discord it turned out, that there is a template-render-call via websocket-client that works for non-admin users.

What I changed:
- use `subscribeRenderTemplate` provided by [card-tools](https://github.com/thomasloven/lovelace-card-tools) to render the template
