### PR TITLE
Register the card with window.customCards

### DIFF
--- a/dist/html-template-card.js
+++ b/dist/html-template-card.js
@@ -94,3 +94,9 @@ class HtmlTemplateCard extends HTMLElement {
 }
 
 customElements.define('html-template-card', HtmlTemplateCard);
+
+window.customCards.push({
+  type: 'html-template-card',
+  name: 'HTML Template Card',
+  description: 'A card that renders the provided Jinja2 template as HTML.'
+});


### PR DESCRIPTION
...thereby causing it to show up in the card type chooser when adding a new card to a dashboard, like so:

<img width="1030" alt="Screen Shot 2022-05-17 at 11 15 29 AM" src="https://user-images.githubusercontent.com/874635/168872583-ded1fe18-72c7-4fc9-a4ac-94934e5e2db0.png">
