### PR TITLE
parametrize card padding and header style

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This card displays provided Jinja2 template as an HTML content of a card. It use
 | `always_update` | `boolean` | `false` | `false` | Enables refreshing the card with every change of entity |
 | `picture_elements_mode` | `boolean` | `false` | `false` | Enables picture-elements mode |
 | `entities` | `list` | `false` | `[]` | List of additional entities whose updates should trigger refresh of the card |
+| `padding` | `string` | `false` | `16px` | padding of `ha-card` element |
+| `header_style` | `string` | `false` | `padding: 8px 0 16px 0;` | in-line CSS for `div.card-header`, which contains card title |
 
 ### Templates
 

--- a/dist/html-template-card.js
+++ b/dist/html-template-card.js
@@ -39,7 +39,7 @@ class HtmlTemplateCard extends HTMLElement {
         }
         if (!this._config.picture_elements_mode) {
             let haCard = document.createElement("ha-card");
-            haCard.style.padding = "16px";
+            haCard.style.padding = this._config.padding ? this._config.padding : "16px";
             this._rootElement = haCard;
         } else {
             this._rootElement = document.createElement("div");
@@ -81,7 +81,8 @@ class HtmlTemplateCard extends HTMLElement {
     render(content) {
         let header = ``;
         if (this._config.title) {
-            header = `<div class="card-header" style="padding: 8px 0 16px 0;"><div class="name">${this._config.title}</div></div>`;
+            let header_style = this._config.header_style ? this._config.header_style : "padding: 8px 0 16px 0;";
+            header = `<div class="card-header" style="${header_style}"><div class="name">${this._config.title}</div></div>`;
         }
         this._rootElement.innerHTML = this._config.picture_elements_mode
             ? content

--- a/info.md
+++ b/info.md
@@ -11,6 +11,8 @@ This card displays provided Jinja2 template as an HTML content of a card. It use
 | `always_update` | `boolean` | `false` | `false` | Enables refreshing the card with every change of entity |
 | `picture_elements_mode` | `boolean` | `false` | `false` | Enables picture-elements mode |
 | `entities` | `list` | `false` | `[]` | List of additional entities whose updates should trigger refresh of the card |
+| `padding` | `string` | `false` | `16px` | padding of `ha-card` element |
+| `header_style` | `string` | `false` | `padding: 8px 0 16px 0;` | in-line CSS for `div.card-header`, which contains card title |
 
 ### Templates
 


### PR DESCRIPTION
Parametrize two things that were set using inline styles and therefore user couldn't override them with built-in `style` or other tools that are just injecting HTML:

- card padding
- header/title div style, which only contained padding definition

Should solve https://github.com/PiotrMachowski/Home-Assistant-Lovelace-HTML-Jinja2-Template-card/issues/18 and similar issues.